### PR TITLE
weave proxy-env deprecated.

### DIFF
--- a/nginx-ubuntu-simple/launch-nginx-demo.sh
+++ b/nginx-ubuntu-simple/launch-nginx-demo.sh
@@ -11,12 +11,12 @@ vagrant ssh weave-gs-03 -c "sudo weave launch-dns; sudo weave launch-proxy" >/de
 
 echo "Launching our example application in two containers on each vagrant host"
 
-vagrant ssh weave-gs-01 -c "eval \$(weave proxy-env); docker run -d --name ws1 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
-vagrant ssh weave-gs-01 -c "eval \$(weave proxy-env); docker run -d --name ws2 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
-vagrant ssh weave-gs-02 -c "eval \$(weave proxy-env); docker run -d --name ws3 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
-vagrant ssh weave-gs-02 -c "eval \$(weave proxy-env); docker run -d --name ws4 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
-vagrant ssh weave-gs-03 -c "eval \$(weave proxy-env); docker run -d --name ws5 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
-vagrant ssh weave-gs-03 -c "eval \$(weave proxy-env); docker run -d --name ws6 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-01 -c "eval \$(weave env); docker run -d --name ws1 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-01 -c "eval \$(weave env); docker run -d --name ws2 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-02 -c "eval \$(weave env); docker run -d --name ws3 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-02 -c "eval \$(weave env); docker run -d --name ws4 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-03 -c "eval \$(weave env); docker run -d --name ws5 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
+vagrant ssh weave-gs-03 -c "eval \$(weave env); docker run -d --name ws6 fintanr/weave-gs-nginx-apache" >/dev/null 2>&1
 
 echo "Launching nginx"
 


### PR DESCRIPTION
Changed the vagrant configuration to accomodate latest weave env changes.
